### PR TITLE
Autodetection

### DIFF
--- a/catalog/consul.go
+++ b/catalog/consul.go
@@ -2,12 +2,13 @@ package catalog
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/hashicorp/go-hclog"
+	hclog "github.com/hashicorp/go-hclog"
 )
 
 const (
@@ -302,11 +303,18 @@ func (c *consul) create(services map[string]service) int {
 					meta[ConsulSourceKey] = ConsulAWSTag
 					meta[ConsulAWSNS] = ns
 					meta[ConsulAWSID] = n.awsID
+
+					p, err := strconv.Atoi(n.attributes["Port"])
+					if err != nil {
+						panic("Bad port")
+					}
+
 					service := api.AgentService{
 						ID:      id,
 						Service: name,
 						Tags:    []string{ConsulAWSTag},
-						Address: h,
+						Address: n.attributes["Address"],
+						Port:    p,
 						Meta:    meta,
 					}
 					if n.port != 0 {
@@ -314,12 +322,12 @@ func (c *consul) create(services map[string]service) int {
 					}
 					reg := api.CatalogRegistration{
 						Node:           ConsulAWSNodeName,
-						Address:        h,
+						Address:        "127.0.0.1",
 						NodeMeta:       map[string]string{ConsulSourceKey: ConsulAWSTag},
 						SkipNodeUpdate: true,
 						Service:        &service,
 					}
-					_, err := c.client.Catalog().Register(&reg, nil)
+					_, err = c.client.Catalog().Register(&reg, nil)
 					if err != nil {
 						c.log.Error("cannot create service", "error", err.Error())
 					} else {

--- a/subcommand/auth.go
+++ b/subcommand/auth.go
@@ -5,6 +5,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	hclog "github.com/hashicorp/go-hclog"
+	"os"
+	"time"
 )
 
 type WithEC2MetadataRegion struct {

--- a/subcommand/auth.go
+++ b/subcommand/auth.go
@@ -2,9 +2,41 @@ package subcommand
 
 import (
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go-v2/aws/external"
+	hclog "github.com/hashicorp/go-hclog"
 )
 
+type WithEC2MetadataRegion struct {
+	Client *ec2metadata.EC2Metadata
+}
+
+func (p WithEC2MetadataRegion) GetRegion() (string, error) {
+	return p.Client.Region()
+}
+
 func AWSConfig() (aws.Config, error) {
-	return external.LoadDefaultAWSConfig()
+	cfg, err := external.LoadDefaultAWSConfig()
+	if err != nil {
+		panic("unable to load SDK config, " + err.Error())
+	}
+
+	region, ok := os.LookupEnv("AWS_REGION")
+	if !ok {
+
+		originalTimeout := cfg.HTTPClient.Timeout
+		cfg.HTTPClient.Timeout = 2 * time.Second
+		metaClient := ec2metadata.New(cfg)
+
+		if !metaClient.Available() {
+			panic("Metadata service cannot be reached.")
+		}
+
+		cfg.HTTPClient.Timeout = originalTimeout
+		hclog.Default().Info("Autodetected region")
+		region, _ = metaClient.Region()
+	}
+
+	cfg.Region = region
+	return cfg, err
 }


### PR DESCRIPTION
As per https://github.com/aws/aws-sdk-go/issues/1103 the AWS SDK leaves it up to users to set or discover the region if AWS_REGION is not set. This is convenient so I've added it.

Additionally I've added an `aws-namespace` flag so you can specify the namespace via a human readable name and it sets aws-namespace-id for you if it finds it.