### PR TITLE
Update test vers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@ version: 2.1
 references:
   images:
     go: &GOLANG_IMAGE circleci/golang:1.12.4
-    consul-current: &CONSUL_IMAGE_CURRENT consul:1.4.4
-    consul-previous: &CONSUL_IMAGE_PREVIOUS consul:1.4.3
+    consul-current: &CONSUL_IMAGE_CURRENT consul:1.5
+    consul-previous: &CONSUL_IMAGE_PREVIOUS consul:1.4
 
 # reusable 'executor' object for jobs
 executors:

--- a/README.md
+++ b/README.md
@@ -78,6 +78,6 @@ go test ./... -run SomeTestFunction_name
 
 ## Compatibility with Consul
 
-`consul-aws` supports the current version of Consul and the version before. At the time of writing this, it means `1.4` and `1.3`.
+`consul-aws` supports the current version of Consul (1.5) and the version before (1.4).
 
 [releases]: https://releases.hashicorp.com/consul-aws "Consul-AWS Releases"


### PR DESCRIPTION
Update the integration tests to use the current version of consul (1.5) and previous (1.4) version. 