### PR TITLE
Do not create Cloud Map services with A+SRV DNS records

### DIFF
--- a/catalog/aws.go
+++ b/catalog/aws.go
@@ -335,7 +335,6 @@ func (a *aws) create(services map[string]service) int {
 			if !a.namespace.isHTTP {
 				input.DnsConfig = &sd.DnsConfig{
 					DnsRecords: []sd.DnsRecord{
-						{TTL: &a.dnsTTL, Type: sd.RecordTypeA},
 						{TTL: &a.dnsTTL, Type: sd.RecordTypeSrv},
 					},
 				}


### PR DESCRIPTION
According to Cloud Map documentation it is not advised to use DNS records of type `A and SRV` at the same time.

The reason is that `SRV` type creates the `A` record implicitly:

> If you specify values for AWS_INSTANCE_IPV4, AWS_INSTANCE_IPV6, or both in the RegisterInstance request, AWS Cloud Map automatically creates A and/or AAAA records that have the same name as the value of service-hostname in the SRV record.

https://docs.aws.amazon.com/cloud-map/latest/api/API_DnsRecord.html

Having a separate `A` record in the configuration requires all instances in given service to have a unique IP address (it is not possible for two instances to share the same IP in DNS).  But this condition is not met when two instances share the same IP and have different service ports. It causes conflicts that block instance registration.