### PR TITLE
support tags, use node address

### DIFF
--- a/catalog/aws.go
+++ b/catalog/aws.go
@@ -363,7 +363,7 @@ func (a *aws) create(services map[string]service) int {
 				wg.Add(1)
 				go func(serviceID, name, h string, n node) {
 					wg.Done()
-					instanceID := id(serviceID, h, n.port)
+					instanceID := n.name
 					attributes := n.attributes
 					attributes["AWS_INSTANCE_IPV4"] = h
 					attributes["AWS_INSTANCE_PORT"] = fmt.Sprintf("%d", n.port)

--- a/catalog/consul.go
+++ b/catalog/consul.go
@@ -138,15 +138,14 @@ func (c *consul) sync(aws *aws, stop, stopped chan struct{}) {
 func (c *consul) transformNodes(cnodes []*api.CatalogService) map[string]map[int]node {
 	nodes := map[string]map[int]node{}
 	for _, n := range cnodes {
-		address := n.ServiceAddress
-		if len(address) == 0 {
-			address = n.Address
-		}
+		// use Address instead of ServiceAddress; RabbitMQ updates the service
+		// address to be its internal DNS instead which breaks stuff
+		address := n.Address
 		if nodes[address] == nil {
 			nodes[address] = map[int]node{}
 		}
 		ports := nodes[address]
-		ports[n.ServicePort] = node{port: n.ServicePort, host: address, consulID: n.ServiceID, awsID: n.ServiceMeta[ConsulAWSID], attributes: n.ServiceMeta}
+		ports[n.ServicePort] = node{name: n.Node, port: n.ServicePort, host: address, consulID: n.ServiceID, awsID: n.ServiceMeta[ConsulAWSID], attributes: n.ServiceMeta}
 		nodes[address] = ports
 	}
 	return nodes

--- a/catalog/service.go
+++ b/catalog/service.go
@@ -27,6 +27,7 @@ type service struct {
 	awsID        string
 	consulID     string
 	awsNamespace string
+	tags         []string
 }
 
 type node struct {

--- a/catalog/service.go
+++ b/catalog/service.go
@@ -30,6 +30,7 @@ type service struct {
 }
 
 type node struct {
+	name       string
 	port       int
 	host       string
 	awsID      string


### PR DESCRIPTION
May not be able to get this upstream but it may be of interest to others:

- includes tags for service syncs, i.e. it will create a service `replica.postgres` and `primary.postgres` and then register instances based on nodes that have that tag (similar to how consul DNS can resolve by tag)
- reduces the size of service instance IDs - we observed that if the `ServiceAddress` is not an IP address but is a hostname, as some consul implementations tend to do, consul-aws would generate a service instance ID that was too long and could not be registered